### PR TITLE
子弹伤害，玩家调整，冰面修改

### DIFF
--- a/Assets/Prefab/BulletAAA.prefab
+++ b/Assets/Prefab/BulletAAA.prefab
@@ -30,7 +30,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -3.69, y: -1.73, z: 0}
-  m_LocalScale: {x: 3.630591, y: 3.630591, z: 3.630591}
+  m_LocalScale: {x: 1.89771, y: 1.89771, z: 1.89771}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -132,7 +132,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.0064100325, y: -0.012806892}
+  m_Offset: {x: 0.010719553, y: -0.023580804}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -143,7 +143,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.35042387, y: 0.31987572}
+  m_Size: {x: 0.25561363, y: 0.15180287}
   m_EdgeRadius: 0
 --- !u!50 &7320485297641338373
 Rigidbody2D:

--- a/Assets/Prefab/Player.prefab
+++ b/Assets/Prefab/Player.prefab
@@ -27,7 +27,7 @@ Transform:
   m_GameObject: {fileID: 444018216146065229}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.01, y: 0.7, z: 0}
+  m_LocalPosition: {x: -0.32, y: 4.29, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -85,7 +85,38 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 8.11
+  m_Radius: 19
+--- !u!1 &4509766843667250734
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7344931883941010600}
+  m_Layer: 0
+  m_Name: iceCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7344931883941010600
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4509766843667250734}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.8, y: -3.13, z: -0.10318582}
+  m_LocalScale: {x: 7.185573, y: 7.185573, z: 7.185573}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2490362664997183438}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5738913565288104817
 GameObject:
   m_ObjectHideFlags: 0
@@ -217,7 +248,38 @@ Transform:
   m_GameObject: {fileID: 7258228166006623572}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.27, y: -1.01, z: 0}
+  m_LocalPosition: {x: 0.68, y: -2.99, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2490362664997183438}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7488806817352202015
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 203011733905959865}
+  m_Layer: 3
+  m_Name: gravityCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &203011733905959865
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7488806817352202015}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -3.09, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -260,11 +322,13 @@ Transform:
   m_Children:
   - {fileID: 6330657645014448544}
   - {fileID: 5387542659658586424}
-  - {fileID: 79039626653087499}
   - {fileID: 7499886764977091819}
   - {fileID: 2040974178005779742}
   - {fileID: 734213828534153614}
   - {fileID: 5400097855894908350}
+  - {fileID: 203011733905959865}
+  - {fileID: 7344931883941010600}
+  - {fileID: 79039626653087499}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &1299491851721384072
@@ -345,25 +409,32 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isReversed: 0
-  speed: 10
-  jumprate: 20
+  speed: 5
+  jumprate: 0
   isOffFire: 0
   isInvincible: 0
   HP: 100
   Key: 0
   invincibilityTime: 2
   offFireTime: 2
-  jumpForce: 10
-  isGravity: 0
-  whatIsGravity:
-    serializedVersion: 2
-    m_Bits: 128
+  jumpForce: 5
   isGrounded: 0
   groundCheck: {fileID: 79039626653087499}
-  groundCheckDistance: 0.5
+  groundCheckDistance: 0.29
   whatIsGround:
     serializedVersion: 2
     m_Bits: 64
+  isGravity: 0
+  gravityCheck: {fileID: 203011733905959865}
+  whatIsGravity:
+    serializedVersion: 2
+    m_Bits: 128
+  gravityCheckDistance: 2.1
+  iceCheck: {fileID: 7344931883941010600}
+  whatIsIce:
+    serializedVersion: 2
+    m_Bits: 0
+  iceCheckDistance: 0.27
   needReverse: 0
   rbVertor: {x: 0, y: 0}
   render: {fileID: 6289010809769570064}
@@ -399,8 +470,8 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.046712738, y: -0.15751456}
-  m_Size: {x: 3.597701, y: 4.8091116}
+  m_Offset: {x: -0.21073326, y: -0.34674215}
+  m_Size: {x: 4.9433117, y: 6.801562}
   m_Direction: 0
 --- !u!70 &3794490468068330196
 CapsuleCollider2D:
@@ -434,8 +505,8 @@ CapsuleCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: -0.046712738, y: -0.15751456}
-  m_Size: {x: 3.597701, y: 4.8091116}
+  m_Offset: {x: -0.26108217, y: -0.3783423}
+  m_Size: {x: 5.0059814, y: 6.7613344}
   m_Direction: 0
 --- !u!114 &2965401527081669422
 MonoBehaviour:
@@ -450,9 +521,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rb: {fileID: 1299491851721384072}
-  upScene: {fileID: 0}
-  bornScene: {fileID: 0}
-  downScren: {fileID: 0}
   camera1UpEdge: 4.25
   camera1DownEdge: -5.81
 --- !u!1001 &163610402497357124

--- a/Assets/Scene/Map 1/MaSongTestMap.meta
+++ b/Assets/Scene/Map 1/MaSongTestMap.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bbd925b3377801940bf4c32739a4de71
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scene/Map 1/MaSongTestMap/Course0.unity
+++ b/Assets/Scene/Map 1/MaSongTestMap/Course0.unity
@@ -208,6 +208,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Platform (7)
       objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.83890975
@@ -278,6 +282,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Platform (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.81086767
@@ -336,67 +344,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
   m_PrefabInstance: {fileID: 41670001}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &53337344
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.04
-      objectReference: {fileID: 0}
-    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.31
-      objectReference: {fileID: 0}
-    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2965401527081669422, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: bornScene
-      value: 
-      objectReference: {fileID: 519420031}
-    - target: {fileID: 7500858245685417121, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
-      propertyPath: m_Name
-      value: Player
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
 --- !u!1001 &56734124
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -482,6 +429,10 @@ PrefabInstance:
     - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_Name
       value: Platform (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
@@ -1375,6 +1326,63 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &454352565
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.04
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.31
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490362664997183438, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7500858245685417121, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a81e9e05bdc2234dbda47d8009f6e19, type: 3}
 --- !u!1001 &466000046
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1386,6 +1394,10 @@ PrefabInstance:
     - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_Name
       value: Platform (12)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
@@ -1458,7 +1470,8 @@ GameObject:
   - component: {fileID: 484068150}
   - component: {fileID: 484068153}
   - component: {fileID: 484068154}
-  m_Layer: 6
+  - component: {fileID: 484068155}
+  m_Layer: 7
   m_Name: Gravity Zone 2
   m_TagString: GravityZone
   m_Icon: {fileID: 0}
@@ -1644,7 +1657,7 @@ EdgeCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 1
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
@@ -1682,11 +1695,63 @@ AreaEffector2D:
     m_Bits: 4294967295
   m_UseGlobalAngle: 0
   m_ForceAngle: 90
-  m_ForceMagnitude: 100
-  m_ForceVariation: 10
+  m_ForceMagnitude: 30
+  m_ForceVariation: 0
   m_ForceTarget: 0
-  m_Drag: 0
+  m_Drag: 0.3
   m_AngularDrag: 0
+--- !u!68 &484068155
+EdgeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 484068149}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_EdgeRadius: 0
+  m_Points:
+  - {x: -2.1310246, y: -1.626735}
+  - {x: -1.728077, y: -2.301651}
+  - {x: -1.2462125, y: -2.6565738}
+  - {x: -0.84721553, y: -2.8361073}
+  - {x: -0.39283216, y: -2.9334526}
+  - {x: -0.0025442606, y: -2.957315}
+  - {x: 0.3519866, y: -2.934566}
+  - {x: 0.6775745, y: -2.8638794}
+  - {x: 0.97804064, y: -2.7453065}
+  - {x: 1.2572069, y: -2.5788965}
+  - {x: 1.5188948, y: -2.3646998}
+  - {x: 1.7669257, y: -2.1027665}
+  - {x: 2.0051212, y: -1.7931472}
+  m_AdjacentStartPoint: {x: 0, y: 0}
+  m_AdjacentEndPoint: {x: 0, y: 0}
+  m_UseAdjacentStartPoint: 0
+  m_UseAdjacentEndPoint: 0
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -2410,6 +2475,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Platform (6)
       objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
       value: 2.2189288
@@ -2559,6 +2628,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Platform (8)
       objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.83890975
@@ -2628,6 +2701,10 @@ PrefabInstance:
     - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_Name
       value: Platform (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
@@ -2775,6 +2852,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Platform (14)
       objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.83890975
@@ -2844,6 +2925,10 @@ PrefabInstance:
     - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_Name
       value: Platform (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
@@ -2916,7 +3001,8 @@ GameObject:
   - component: {fileID: 1450224595}
   - component: {fileID: 1450224594}
   - component: {fileID: 1450224593}
-  m_Layer: 6
+  - component: {fileID: 1450224597}
+  m_Layer: 7
   m_Name: Gravity Zone 2 (1)
   m_TagString: GravityZone
   m_Icon: {fileID: 0}
@@ -2953,10 +3039,10 @@ AreaEffector2D:
     m_Bits: 4294967295
   m_UseGlobalAngle: 0
   m_ForceAngle: 90
-  m_ForceMagnitude: 100
-  m_ForceVariation: 10
+  m_ForceMagnitude: 30
+  m_ForceVariation: 0
   m_ForceTarget: 0
-  m_Drag: 0
+  m_Drag: 0.3
   m_AngularDrag: 0
 --- !u!68 &1450224594
 EdgeCollider2D:
@@ -2987,7 +3073,7 @@ EdgeCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 1
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
@@ -3145,6 +3231,58 @@ SpriteShapeRenderer:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_SpriteSortPoint: 0
+--- !u!68 &1450224597
+EdgeCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1450224591}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_EdgeRadius: 0
+  m_Points:
+  - {x: -2.1310246, y: -1.626735}
+  - {x: -1.728077, y: -2.301651}
+  - {x: -1.2462125, y: -2.6565738}
+  - {x: -0.84721553, y: -2.8361073}
+  - {x: -0.39283216, y: -2.9334526}
+  - {x: -0.0025442606, y: -2.957315}
+  - {x: 0.3519866, y: -2.934566}
+  - {x: 0.6775745, y: -2.8638794}
+  - {x: 0.97804064, y: -2.7453065}
+  - {x: 1.2572069, y: -2.5788965}
+  - {x: 1.5188948, y: -2.3646998}
+  - {x: 1.7669257, y: -2.1027665}
+  - {x: 2.0051212, y: -1.7931472}
+  m_AdjacentStartPoint: {x: 0, y: 0}
+  m_AdjacentEndPoint: {x: 0, y: 0}
+  m_UseAdjacentStartPoint: 0
+  m_UseAdjacentEndPoint: 0
 --- !u!1001 &1451616741
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3523,6 +3661,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Platform (9)
       objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
       value: 1.3863986
@@ -3592,6 +3734,10 @@ PrefabInstance:
     - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_Name
       value: Platform
+      objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
@@ -3797,6 +3943,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Platform (3)
       objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
       value: 1.3863986
@@ -3867,6 +4017,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Platform (4)
       objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
       value: 0.83890975
@@ -3936,6 +4090,10 @@ PrefabInstance:
     - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_Name
       value: Platform (13)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
@@ -4270,6 +4428,10 @@ PrefabInstance:
     - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_Name
       value: Platform (11)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6500539675003461811, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
+      propertyPath: m_Layer
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 8492335747520666585, guid: e97d4ddb07494e045832aa0c485e3907, type: 3}
       propertyPath: m_LocalScale.x
@@ -4686,6 +4848,63 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6294393357330918958, guid: 9d95b824fb56d8548b6d811c50d507ca, type: 3}
   m_PrefabInstance: {fileID: 2137166189}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3774985781464808981
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7117900467026815495, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
+      propertyPath: m_Name
+      value: BulletAAA
+      objectReference: {fileID: 0}
+    - target: {fileID: 7584037219422144843, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.48379213
+      objectReference: {fileID: 0}
+    - target: {fileID: 7584037219422144843, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.7279567
+      objectReference: {fileID: 0}
+    - target: {fileID: 7584037219422144843, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7584037219422144843, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7584037219422144843, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7584037219422144843, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7584037219422144843, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7584037219422144843, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7584037219422144843, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7584037219422144843, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0b373342e5c8ab94a845a12665eaa7fb, type: 3}
 --- !u!1001 &6199268552757472605
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4752,4 +4971,5 @@ SceneRoots:
   - {fileID: 2003341699}
   - {fileID: 1816030042}
   - {fileID: 1971447481}
-  - {fileID: 53337344}
+  - {fileID: 454352565}
+  - {fileID: 3774985781464808981}

--- a/Assets/Scene/Map 1/MaSongTestMap/Course0.unity.meta
+++ b/Assets/Scene/Map 1/MaSongTestMap/Course0.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d2723281b0bbd0745a1175d51df5af7d
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/EnemyScript/Bullet.cs
+++ b/Assets/Scripts/EnemyScript/Bullet.cs
@@ -25,7 +25,9 @@ public class Bullet : MonoBehaviour
             Destroy(gameObject);
         }
         if (collision.gameObject.tag == "Player")//如果碰撞对象是玩家
+
         {
+            collision.gameObject.GetComponent<Player>().Hurt(1);
             Destroy(gameObject);
             
         }

--- a/Assets/Scripts/Environment/HurtManager.cs
+++ b/Assets/Scripts/Environment/HurtManager.cs
@@ -41,10 +41,7 @@ public class HurtManager : MonoBehaviour
                 }
 
             }
-            else if (gameObject.tag == "Bullet")
-            {
-                playerScript.Hurt(1);
-            }
+            
         }
     }
 

--- a/Assets/Scripts/Player/CameraControl.cs
+++ b/Assets/Scripts/Player/CameraControl.cs
@@ -7,17 +7,23 @@ public class CameraControl : MonoBehaviour
 {
     public Rigidbody2D rb;
     private Vector2 position;
-    public Camera upScene;
-    public Camera bornScene;
-    public Camera downScren;
+    private Camera upScene;
+    private Camera bornScene;
+    private Camera downScren;
+    private GameObject Map;
     [Header("基本参数")]
     public float camera1UpEdge;
     public float camera1DownEdge;
+
     
 
     private void Awake()
     {
-       rb = GetComponent<Rigidbody2D>();
+        Map = GameObject.Find("Map");
+        upScene = Map.transform.Find("Main Camera (1)").GetComponent<Camera>();
+        bornScene = Map.transform.Find("Main Camera").GetComponent<Camera>();
+        downScren = Map.transform.Find("Main Camera (2)").GetComponent<Camera>();
+        rb = GetComponent<Rigidbody2D>();
     }
     private void Update()
     {

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -10,7 +10,7 @@ public class Player : MonoBehaviour
     [Header("基础信息")]
     public bool isReversed;
     public float speed;
-    public float jumprate;
+    [SerializeField] float iceSpeedRate = 1.2f;
     public bool isOffFire = false;
     public bool isInvincible = false;
     public int HP = 2;
@@ -21,12 +21,23 @@ public class Player : MonoBehaviour
     [SerializeField] private float jumpForce;
     [Space]
     [Header("地面检测")]
-    public bool isGravity;
-    [SerializeField] private LayerMask whatIsGravity;
     [SerializeField] private bool isGrounded;
     [SerializeField] private Transform groundCheck;
     [SerializeField] private float groundCheckDistance;
     [SerializeField] private LayerMask whatIsGround;
+
+
+    public bool isGravity;
+    [SerializeField] private Transform gravityCheck;
+    [SerializeField] private LayerMask whatIsGravity;
+    [SerializeField] private float gravityCheckDistance;
+
+    private bool isIced;
+    [SerializeField] private Transform iceCheck;
+    [SerializeField] private LayerMask whatIsIce;
+    [SerializeField] private float iceCheckDistance;
+
+
     [Space]
     [Header("是否反转操作")]
     [SerializeField] private bool needReverse;
@@ -61,6 +72,10 @@ public class Player : MonoBehaviour
         rbVertor = rb.velocity;
         CountTimeForFireOff();
         animator.SetFloat("velocityX", (rbVertor.x<0?-rbVertor.x:rbVertor.x));
+        if (isIced)
+        {
+            IceSpeedUP();
+        }
 
     }
 
@@ -80,30 +95,20 @@ public class Player : MonoBehaviour
 
     void OnReverse(InputValue value)
     {
-        if (value.isPressed)
+        if (isGravity)
         {
-            isReversed = !isReversed; // �л�״̬
-            rb.gravityScale = -rb.gravityScale;
-
-            transform.Rotate(0, 180, 180);
-
-        }
-    }
-
-    void OnJump(InputValue value)
-    {
-        Vector2 movevalue = value.Get<Vector2>();
-        if (isGrounded) { 
-            if (!isReversed)
+            if (value.isPressed)
             {
-                rb.velocity = new Vector2(rb.velocity.x, movevalue.y * jumprate);
-            }else
-            {
-                rb.velocity = new Vector2(rb.velocity.x, -movevalue.y * jumprate);
+                isReversed = !isReversed; // �л�״̬
+                rb.gravityScale = -rb.gravityScale;
+
+                transform.Rotate(0, 180, 180);
+
             }
         }
-
     }
+
+    
 
     void OnMove(InputValue value)  
     {
@@ -210,11 +215,17 @@ public class Player : MonoBehaviour
     private void CollsionCheck()
     {
         isGrounded = Physics2D.Raycast(groundCheck.position, Vector2.down, groundCheckDistance, whatIsGround);
-        isGravity = Physics2D.Raycast(groundCheck.position, Vector2.down, groundCheckDistance, whatIsGravity);
+        isGravity = Physics2D.Raycast(gravityCheck.position, Vector2.down, gravityCheckDistance, whatIsGravity);
+        isIced = Physics2D.Raycast(iceCheck.position, Vector2.down, iceCheckDistance, whatIsIce);
     }
     private void OnDrawGizmos()
     {
+        Gizmos.color = Color.green;
         Gizmos.DrawLine(groundCheck.position, new Vector3(groundCheck.position.x, groundCheck.position.y - groundCheckDistance));
+        Gizmos.color = Color.yellow;
+        Gizmos.DrawLine(gravityCheck.position, new Vector3(gravityCheck.position.x, gravityCheck.position.y - gravityCheckDistance));
+        Gizmos.color = new Color(0, 255, 255);
+        Gizmos.DrawLine(iceCheck.position, new Vector3(iceCheck.position.x, iceCheck.position.y - iceCheckDistance));
     }
 
 
@@ -238,5 +249,10 @@ public class Player : MonoBehaviour
     public bool IsReversed()
     {
         return isReversed;
+    }
+
+    public void IceSpeedUP()
+    {
+        rb.velocity = new Vector2(rb.velocity.x * iceSpeedRate, rb.velocity.y);
     }
 }


### PR DESCRIPTION
怪物的子弹现在可以正确伤害玩家，提供了公开方法IceSpeedUp()来修改人物的移动速度，现在可以正确修改isGravity了，添加了三个辅助线（绿色是地面检测，黄色是重力检测，青色是冰块检测）
悬浮区域数值修改：Force Magnitude = 30， Drag = 0.3，同时要多复制一个edgeCollider防止人物掉下去


![屏幕截图 2025-02-11 212720](https://github.com/user-attachments/assets/96ff5b17-0fcf-4b0c-be09-cb4e49d09848)
![屏幕截图 2025-02-11 211422](https://github.com/user-attachments/assets/2e097164-da0f-4409-a935-b5fd2f60db7d)
